### PR TITLE
#70 Supprimer les etiquettes dupliquees lors de l'affichage

### DIFF
--- a/src/app/components/Cards/BoardCard/BoardCard.tsx
+++ b/src/app/components/Cards/BoardCard/BoardCard.tsx
@@ -18,108 +18,113 @@ interface IBoardCardProps {
   member: IBoardMember;
   fullCard: boolean;
   blurCard: boolean;
+  currentPageCode: string;
   setFullMemberIndexCallback: () => void;
 }
 
-export default function BoardCard({ language, t, member, fullCard, blurCard, setFullMemberIndexCallback }: IBoardCardProps): JSX.Element {
+export default function BoardCard({ language, t, member, fullCard, blurCard, currentPageCode, setFullMemberIndexCallback }: IBoardCardProps): JSX.Element {
   if (fullCard) {
     return (
-      <div className='boardCard boardCard-full' onClick={setFullMemberIndexCallback}>
-        <div className='boardCard-full-initial'>
-          <div className='boardCard-full-initial-person'>
-            <div className='boardCard-full-initial-person-picture'>
-              {member.picture ? (
-                <img src={member.picture} alt={`${member.firstname} ${member.lastname} picture`}/>
-              ) : (
-                <img className='boardCard-person-picture-placeholder' src={user} alt='User icon' />
-              )}
-            </div>
-            <div className='boardCard-full-initial-person-title'>
-              <div className='boardCard-full-initial-person-title-name'>
-                <div className='boardCard-full-initial-person-title-name-text'>{member.firstname} {member.lastname}</div>
-                {member.orcid && member.orcid.length > 0 && (
-                  <Link to={`${import.meta.env.VITE_ORCID_HOMEPAGE}/${member.orcid}`} title={member.orcid} target='_blank' onClick={(e) => e.stopPropagation()}>
-                    <img className='boardCard-full-initial-person-title-name-orcid' src={orcid} alt='Orcid icon' />
-                  </Link>
+        <div className='boardCard boardCard-full' onClick={setFullMemberIndexCallback}>
+          <div className='boardCard-full-initial'>
+            <div className='boardCard-full-initial-person'>
+              <div className='boardCard-full-initial-person-picture'>
+                {member.picture ? (
+                    <img src={member.picture} alt={`${member.firstname} ${member.lastname} picture`}/>
+                ) : (
+                    <img className='boardCard-person-picture-placeholder' src={user} alt='User icon' />
                 )}
               </div>
-              {member.roles.length > 0 ? (
-                <div className='boardCard-full-initial-person-title-role'>{getBoardRoles(t, member.roles)}</div>
-              ) : (
-                <div className='boardCard-full-initial-person-title-role'>{defaultBoardRole(t).label}</div>
-              )}
-            </div>
-          </div>
-          {member.affiliations.length > 0 && <div className='boardCard-full-initial-affiliations'>{member.affiliations[0].label}</div>}
-          {member.assignedSections.length > 0 && <div className='boardCard-full-initial-assignedSections'>{member.assignedSections.map((assignedSection) => assignedSection.title[language]).join(', ')}</div>}
-        </div>
-        <div className='boardCard-full-expanded'>
-          {member.email && (
-            <Link to={`mailto:${member.email}`} target='_blank' onClick={(e) => e.stopPropagation()}>
-              <div className='boardCard-full-expanded-email'>
-                <img className='boardCard-full-expanded-email-at' src={at} alt={`At ${member.email} icon`}/>
-                <div>{member.email}</div>
-              </div>
-            </Link>
-          )}
-          <div className='boardCard-full-expanded-biography'>{member.biography}</div>
-          <div className='boardCard-full-expanded-social'>
-            {(member.twitter || member.mastodon) && (
-              <div className='boardCard-full-expanded-social-networks'>
-                {member.twitter && (
-                  <Link to={member.twitter} title={member.twitter} target='_blank' onClick={(e) => e.stopPropagation()}>
-                    <img className='boardCard-full-expanded-social-networks-icon' src={twitter} alt='Twitter icon' />
-                  </Link>
-                )}
-                {member.mastodon && (
-                  <Link to={member.mastodon} title={member.mastodon} target='_blank' onClick={(e) => e.stopPropagation()}>
-                    <img className='boardCard-full-expanded-social-networks-icon' src={mastodon} alt='Mastodon icon' />
-                  </Link>
-                )}
-              </div>
-            )}
-            {member.website && (
-              <Link to={member.website} title={member.website} target='_blank' onClick={(e) => e.stopPropagation()}>
-                <div className='boardCard-full-expanded-social-website'>
-                  <div>Website</div>
-                  <img className='boardCard-full-expanded-social-website-img' src={externalLink} alt='Website link icon' />
+              <div className='boardCard-full-initial-person-title'>
+                <div className='boardCard-full-initial-person-title-name'>
+                  <div className='boardCard-full-initial-person-title-name-text'>{member.firstname} {member.lastname}</div>
+                  {member.orcid && member.orcid.length > 0 && (
+                      <Link to={`${import.meta.env.VITE_ORCID_HOMEPAGE}/${member.orcid}`} title={member.orcid} target='_blank' onClick={(e) => e.stopPropagation()}>
+                        <img className='boardCard-full-initial-person-title-name-orcid' src={orcid} alt='Orcid icon' />
+                      </Link>
+                  )}
                 </div>
-              </Link>
+                {member.roles.length > 0 ? (
+                    <div className='boardCard-full-initial-person-title-role'>{getBoardRoles(t, member.roles.filter(role =>
+                        role !== currentPageCode && `${role}s` !== currentPageCode
+                    ))}</div>
+                ) : (
+                    <div className='boardCard-full-initial-person-title-role'>{defaultBoardRole(t).label}</div>
+                )}
+              </div>
+            </div>
+            {member.affiliations.length > 0 && <div className='boardCard-full-initial-affiliations'>{member.affiliations[0].label}</div>}
+            {member.assignedSections.length > 0 && <div className='boardCard-full-initial-assignedSections'>{member.assignedSections.map((assignedSection) => assignedSection.title[language]).join(', ')}</div>}
+          </div>
+          <div className='boardCard-full-expanded'>
+            {member.email && (
+                <Link to={`mailto:${member.email}`} target='_blank' onClick={(e) => e.stopPropagation()}>
+                  <div className='boardCard-full-expanded-email'>
+                    <img className='boardCard-full-expanded-email-at' src={at} alt={`At ${member.email} icon`}/>
+                    <div>{member.email}</div>
+                  </div>
+                </Link>
             )}
+            <div className='boardCard-full-expanded-biography'>{member.biography}</div>
+            <div className='boardCard-full-expanded-social'>
+              {(member.twitter || member.mastodon) && (
+                  <div className='boardCard-full-expanded-social-networks'>
+                    {member.twitter && (
+                        <Link to={member.twitter} title={member.twitter} target='_blank' onClick={(e) => e.stopPropagation()}>
+                          <img className='boardCard-full-expanded-social-networks-icon' src={twitter} alt='Twitter icon' />
+                        </Link>
+                    )}
+                    {member.mastodon && (
+                        <Link to={member.mastodon} title={member.mastodon} target='_blank' onClick={(e) => e.stopPropagation()}>
+                          <img className='boardCard-full-expanded-social-networks-icon' src={mastodon} alt='Mastodon icon' />
+                        </Link>
+                    )}
+                  </div>
+              )}
+              {member.website && (
+                  <Link to={member.website} title={member.website} target='_blank' onClick={(e) => e.stopPropagation()}>
+                    <div className='boardCard-full-expanded-social-website'>
+                      <div>Website</div>
+                      <img className='boardCard-full-expanded-social-website-img' src={externalLink} alt='Website link icon' />
+                    </div>
+                  </Link>
+              )}
+            </div>
           </div>
         </div>
-      </div>
     )
   }
 
   return (
-    <div className={blurCard ? 'boardCard boardCard-blur' : 'boardCard'} onClick={setFullMemberIndexCallback}>
-      <div className='boardCard-person'>
-        <div className='boardCard-person-picture'>
-          {member.picture ? (
-            <img src={member.picture} alt={`${member.firstname} ${member.lastname} picture`}/>
-          ) : (
-            <img className='boardCard-person-picture-placeholder' src={user} alt='User icon' />
-          )}
-        </div>
-        <div className='boardCard-person-title'>
-          <div className='boardCard-person-title-name'>
-            <div className='boardCard-person-title-name-text'>{member.firstname} {member.lastname}</div>
-            {member.orcid && member.orcid.length > 0 && (
-              <Link to={`${import.meta.env.VITE_ORCID_HOMEPAGE}/${member.orcid}`} title={member.orcid} target='_blank' onClick={(e) => e.stopPropagation()}>
-                <img className='boardCard-person-title-name-orcid' src={orcid} alt='Orcid icon' />
-              </Link>
+      <div className={blurCard ? 'boardCard boardCard-blur' : 'boardCard'} onClick={setFullMemberIndexCallback}>
+        <div className='boardCard-person'>
+          <div className='boardCard-person-picture'>
+            {member.picture ? (
+                <img src={member.picture} alt={`${member.firstname} ${member.lastname} picture`}/>
+            ) : (
+                <img className='boardCard-person-picture-placeholder' src={user} alt='User icon' />
             )}
           </div>
-          {member.roles.length > 0 ? (
-            <div className='boardCard-person-title-role'>{getBoardRoles(t, member.roles)}</div>
-          ) : (
-            <div className='boardCard-person-title-role'>{defaultBoardRole(t).label}</div>
-          )}
+          <div className='boardCard-person-title'>
+            <div className='boardCard-person-title-name'>
+              <div className='boardCard-person-title-name-text'>{member.firstname} {member.lastname}</div>
+              {member.orcid && member.orcid.length > 0 && (
+                  <Link to={`${import.meta.env.VITE_ORCID_HOMEPAGE}/${member.orcid}`} title={member.orcid} target='_blank' onClick={(e) => e.stopPropagation()}>
+                    <img className='boardCard-person-title-name-orcid' src={orcid} alt='Orcid icon' />
+                  </Link>
+              )}
+            </div>
+            {member.roles.length > 0 ? (
+                <div className='boardCard-person-title-role'>{getBoardRoles(t, member.roles.filter(role =>
+                    role !== currentPageCode && `${role}s` !== currentPageCode
+                ))}</div>
+            ) : (
+                <div className='boardCard-person-title-role'>{defaultBoardRole(t).label}</div>
+            )}
+          </div>
         </div>
+        {member.affiliations.length > 0 && <div className='boardCard-affiliations'>{member.affiliations[0].label}</div>}
+        {member.assignedSections.length > 0 && <div className='boardCard-assignedSections'>{member.assignedSections.map((assignedSection) => assignedSection.title[language]).join(', ')}</div>}
       </div>
-      {member.affiliations.length > 0 && <div className='boardCard-affiliations'>{member.affiliations[0].label}</div>}
-      {member.assignedSections.length > 0 && <div className='boardCard-assignedSections'>{member.assignedSections.map((assignedSection) => assignedSection.title[language]).join(', ')}</div>}
-    </div>
   )
 }

--- a/src/app/pages/Boards/Boards.tsx
+++ b/src/app/pages/Boards/Boards.tsx
@@ -18,6 +18,7 @@ interface IBoardPerTitle {
   title: string;
   description: string;
   members: IBoardMember[];
+  pageCode: string;
 }
 
 export default function Boards(): JSX.Element {
@@ -54,16 +55,18 @@ export default function Boards(): JSX.Element {
     pages.forEach((page) => {
       const title = page.title[language];
       const description = page.content[language];
+      const pageCode = page.page_code;
 
       const pageMembers = members.filter((member) => {
         const pluralRoles = member.roles.map((role) => `${role}s`)
-        return member.roles.includes(page.page_code) || pluralRoles.includes(page.page_code);
+        return member.roles.includes(pageCode) || pluralRoles.includes(pageCode);
       });
 
       boardsPerTitle.push({
         title,
         description,
-        members: pageMembers
+        members: pageMembers,
+        pageCode
       })
     })
 
@@ -75,63 +78,64 @@ export default function Boards(): JSX.Element {
   };
 
   return (
-    <main className='boards'>
+      <main className='boards'>
 
-      <Helmet>
-        <title>{t('pages.boards.title')} | {journalName ?? ''}</title>
-      </Helmet>
+        <Helmet>
+          <title>{t('pages.boards.title')} | {journalName ?? ''}</title>
+        </Helmet>
 
-      <Breadcrumb parents={[
-        { path: 'home', label: `${t('pages.home.title')} >` }
-      ]} crumbLabel={t('pages.boards.title')} />
-      <div className='boards-title'>
-        <h1 className='boards-title-text'>{t('pages.boards.title')}</h1>
-        {members && members.length > 0 && (
-          members.length > 1 ? (
-            <div className='boards-title-count'>{members.length} {t('common.members')}</div>
-        ) : (
-            <div className='boards-title-count'>{members.length} {t('common.member')}</div>
-        ))}
-      </div>
-      {isFetchingPages || isFetchingMembers ? (
-        <Loader />
-      ) : (
-        <div className='boards-content'>
-          <BoardsSidebar t={t} groups={getPagesLabels()} activeGroupIndex={activeGroupIndex} onSetActiveGroupCallback={handleGroupToggle} />
-          <div className='boards-content-groups'>
-            {getBoardsPerTitle().map((boardPerTitle, index) => (
-              <div key={index} className='boards-content-groups-group'>
-                <div className='boards-content-groups-group-title' onClick={(): void => activeGroupIndex === index ? handleGroupToggle(-1) : handleGroupToggle(index)}>
-                  <h2>{boardPerTitle.title}</h2>
-                  {activeGroupIndex === index ? (
-                    <img className='boards-content-groups-group-caret' src={caretUp} alt='Caret up icon' />
-                  ) : (
-                    <img className='boards-content-groups-group-caret' src={caretDown} alt='Caret down icon' />
-                  )}
-                </div>
-                <div className={`boards-content-groups-group-content ${activeGroupIndex === index && 'boards-content-groups-group-content-active'}`}>
-                  <div className='boards-content-groups-group-content-description'>
-                    <ReactMarkdown>{boardPerTitle.description}</ReactMarkdown>
-                  </div>
-                  <div className='boards-content-groups-group-content-grid'>
-                    {boardPerTitle.members.map((member, index) => (
-                      <BoardCard
-                        key={index}
-                        language={language}
-                        t={t}
-                        member={member}
-                        fullCard={fullMemberIndex === index}
-                        blurCard={fullMemberIndex !== -1 && fullMemberIndex !== index}
-                        setFullMemberIndexCallback={(): void => fullMemberIndex !== index ? setFullMemberIndex(index) : setFullMemberIndex(-1)}
-                      />
-                    ))}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+        <Breadcrumb parents={[
+          { path: 'home', label: `${t('pages.home.title')} >` }
+        ]} crumbLabel={t('pages.boards.title')} />
+        <div className='boards-title'>
+          <h1 className='boards-title-text'>{t('pages.boards.title')}</h1>
+          {members && members.length > 0 && (
+              members.length > 1 ? (
+                  <div className='boards-title-count'>{members.length} {t('common.members')}</div>
+              ) : (
+                  <div className='boards-title-count'>{members.length} {t('common.member')}</div>
+              ))}
         </div>
-      )}
-    </main>
+        {isFetchingPages || isFetchingMembers ? (
+            <Loader />
+        ) : (
+            <div className='boards-content'>
+              <BoardsSidebar t={t} groups={getPagesLabels()} activeGroupIndex={activeGroupIndex} onSetActiveGroupCallback={handleGroupToggle} />
+              <div className='boards-content-groups'>
+                {getBoardsPerTitle().map((boardPerTitle, index) => (
+                    <div key={index} className='boards-content-groups-group'>
+                      <div className='boards-content-groups-group-title' onClick={(): void => activeGroupIndex === index ? handleGroupToggle(-1) : handleGroupToggle(index)}>
+                        <h2>{boardPerTitle.title}</h2>
+                        {activeGroupIndex === index ? (
+                            <img className='boards-content-groups-group-caret' src={caretUp} alt='Caret up icon' />
+                        ) : (
+                            <img className='boards-content-groups-group-caret' src={caretDown} alt='Caret down icon' />
+                        )}
+                      </div>
+                      <div className={`boards-content-groups-group-content ${activeGroupIndex === index && 'boards-content-groups-group-content-active'}`}>
+                        <div className='boards-content-groups-group-content-description'>
+                          <ReactMarkdown>{boardPerTitle.description}</ReactMarkdown>
+                        </div>
+                        <div className='boards-content-groups-group-content-grid'>
+                          {boardPerTitle.members.map((member, index) => (
+                              <BoardCard
+                                  key={index}
+                                  language={language}
+                                  t={t}
+                                  member={member}
+                                  currentPageCode={boardPerTitle.pageCode}
+                                  fullCard={fullMemberIndex === index}
+                                  blurCard={fullMemberIndex !== -1 && fullMemberIndex !== index}
+                                  setFullMemberIndexCallback={(): void => fullMemberIndex !== index ? setFullMemberIndex(index) : setFullMemberIndex(-1)}
+                              />
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                ))}
+              </div>
+            </div>
+        )}
+      </main>
   )
 }


### PR DESCRIPTION
L'affichage des étiquettes sur les tuiles fait doublon avec les intitulés, donc il conviendrait de ne pas afficher les étiquettes sur les tuiles. En revanche, il faut conserver les rôles.