### PR TITLE
#70 ne pas afficher les étiquettes (doublon)

### DIFF
--- a/src/app/components/Cards/BoardCard/BoardCard.tsx
+++ b/src/app/components/Cards/BoardCard/BoardCard.tsx
@@ -18,10 +18,11 @@ interface IBoardCardProps {
   member: IBoardMember;
   fullCard: boolean;
   blurCard: boolean;
+  currentPageCode: string;
   setFullMemberIndexCallback: () => void;
 }
 
-export default function BoardCard({ language, t, member, fullCard, blurCard, setFullMemberIndexCallback }: IBoardCardProps): JSX.Element {
+export default function BoardCard({ language, t, member, fullCard, blurCard, currentPageCode, setFullMemberIndexCallback }: IBoardCardProps): JSX.Element {
   if (fullCard) {
     return (
       <div className='boardCard boardCard-full' onClick={setFullMemberIndexCallback}>
@@ -44,7 +45,8 @@ export default function BoardCard({ language, t, member, fullCard, blurCard, set
                 )}
               </div>
               {member.roles.length > 0 ? (
-                <div className='boardCard-full-initial-person-title-role'>{getBoardRoles(t, member.roles)}</div>
+                <div className='boardCard-full-initial-person-title-role'>{getBoardRoles(t, member.roles.filter(role =>
+                    role !== currentPageCode && `${role}s` !== currentPageCode))}</div>
               ) : (
                 <div className='boardCard-full-initial-person-title-role'>{defaultBoardRole(t).label}</div>
               )}
@@ -112,7 +114,8 @@ export default function BoardCard({ language, t, member, fullCard, blurCard, set
             )}
           </div>
           {member.roles.length > 0 ? (
-            <div className='boardCard-person-title-role'>{getBoardRoles(t, member.roles)}</div>
+            <div className='boardCard-person-title-role'>{getBoardRoles(t, member.roles.filter(role =>
+                role !== currentPageCode && `${role}s` !== currentPageCode))}</div>
           ) : (
             <div className='boardCard-person-title-role'>{defaultBoardRole(t).label}</div>
           )}

--- a/src/app/pages/Boards/Boards.tsx
+++ b/src/app/pages/Boards/Boards.tsx
@@ -18,6 +18,7 @@ interface IBoardPerTitle {
   title: string;
   description: string;
   members: IBoardMember[];
+  pageCode:string;
 }
 
 export default function Boards(): JSX.Element {
@@ -54,16 +55,18 @@ export default function Boards(): JSX.Element {
     pages.forEach((page) => {
       const title = page.title[language];
       const description = page.content[language];
+      const pageCode = page.page_code;
 
       const pageMembers = members.filter((member) => {
         const pluralRoles = member.roles.map((role) => `${role}s`)
-        return member.roles.includes(page.page_code) || pluralRoles.includes(page.page_code);
+        return member.roles.includes(pageCode) || pluralRoles.includes(pageCode);
       });
 
       boardsPerTitle.push({
         title,
         description,
-        members: pageMembers
+        members: pageMembers,
+        pageCode,
       })
     })
 
@@ -120,6 +123,7 @@ export default function Boards(): JSX.Element {
                         language={language}
                         t={t}
                         member={member}
+                        currentPageCode={boardPerTitle.pageCode}
                         fullCard={fullMemberIndex === index}
                         blurCard={fullMemberIndex !== -1 && fullMemberIndex !== index}
                         setFullMemberIndexCallback={(): void => fullMemberIndex !== index ? setFullMemberIndex(index) : setFullMemberIndex(-1)}


### PR DESCRIPTION
L'affichage des étiquettes sur les tuiles fait doublon avec les intitulés, donc il conviendrait de ne pas afficher les étiquettes sur les tuiles. En revanche, il faut conserver les rôles.