### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/src/app/pages/ForAuthors/ForAuthors.tsx
+++ b/src/app/pages/ForAuthors/ForAuthors.tsx
@@ -30,7 +30,7 @@ export default function ForAuthors(): JSX.Element {
 
   const language = useAppSelector(state => state.i18nReducer.language);
   const rvcode = useAppSelector(state => state.journalReducer.currentJournal?.code);
-  const journalName = useAppSelector(state => state.journalReducer.currentJournal?.name)
+  const journalName = useAppSelector(state => state.journalReducer.currentJournal?.name);
 
   const [pageSections, setPageSections] = useState<IForAuthorsSection[]>([]);
   const [sidebarHeaders, setSidebarHeaders] = useState<IForAuthorsHeader[]>([]);


### PR DESCRIPTION
To address the issue, add a semicolon at the end of the `const journalName = useAppSelector(state => state.journalReducer.currentJournal?.name)` statement (line 33). This brings the code into alignment with the project's established style, which is to use explicit semicolons at the end of statements, improving readability and maintainability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._