### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/app/components/PDFViewer/PDFViewer.tsx
+++ b/src/app/components/PDFViewer/PDFViewer.tsx
@@ -27,7 +27,14 @@ export default function PDFViewer({ pdfUrl, showDownloadButton = false, prominen
   const [error, setError] = useState<string | null>(null);
 
   // Detect if PDF is from Zenodo - use react-pdf for better compatibility
-  const isZenodo = useMemo(() => pdfUrl.includes('zenodo.org'), [pdfUrl]);
+  const isZenodo = useMemo(() => {
+    try {
+      const { hostname } = new URL(pdfUrl);
+      return hostname === 'zenodo.org' || hostname.endsWith('.zenodo.org');
+    } catch (error) {
+      return false;
+    }
+  }, [pdfUrl]);
 
   // Memoize file and options to prevent unnecessary re-renders
   const fileConfig = useMemo(() => ({ url: pdfUrl }), [pdfUrl]);


### PR DESCRIPTION
Potential fix for [https://github.com/CCSDForge/episciences-front/security/code-scanning/2](https://github.com/CCSDForge/episciences-front/security/code-scanning/2)

To correctly determine whether the provided URL belongs to `zenodo.org`, the code should parse the URL using the standard `URL` class and examine its host (or hostname) property. The logic should check whether the hostname is exactly `zenodo.org` or a subdomain of it.  
- Change the `useMemo` logic constructing `isZenodo` to parse the URL and test `hostname`.
- Use either strict equality (`hostname === "zenodo.org"`) or ends-with logic (`hostname.endsWith('.zenodo.org')`), or both (allowing subdomains as well as the main domain, but not e.g. `evilzenodo.org`).
- The URL class is globally available in modern browsers/Node, no need for external packages.
- Wrap in a try-catch, as `URL` constructor may throw on bad strings.
- All modifications are to code in `src/app/components/PDFViewer/PDFViewer.tsx` at the declaration of `isZenodo`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
