### PR TITLE
feat(#94):Nouvelles étiquettes pour les boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config for CodeQL
 - Config for Dependabot
 - Status page link in footer
+- feat: add new pages for About, Boards, and Publish
+- feat(#94): update editor labels for Scientific and Editorial boards
 
 ### Fixed
 - Volume page, display other volumes with a link

--- a/public/locales/en/en.json
+++ b/public/locales/en/en.json
@@ -377,7 +377,10 @@
         "editor": "Editor",
         "chiefEditor": "Chief editor",
         "secretary": "Secretary",
-        "formerMember": "Former member"
+        "formerMember": "Former member",
+        "advisoryBoard": "Advisory board",
+        "managingEditor": "Managing editor",
+        "handlingEditor": "Handling editor"
       }
     },
     "publish": {

--- a/public/locales/fr/fr.json
+++ b/public/locales/fr/fr.json
@@ -377,7 +377,10 @@
         "editor": "Rédacteur/Rédactrice",
         "chiefEditor": "Rédacteur/Rédactrice en chef",
         "secretary": "Secrétaire de rédaction",
-        "formerMember": "Ancien/Ancienne membre"
+        "formerMember": "Ancien/Ancienne membre",
+        "advisoryBoard": "Comité consultatif",
+        "managingEditor": "Comité de direction",
+        "handlingEditor": "Rédacteur responsable"
       }
     },
     "publish": {

--- a/src/app/pages/Boards/Boards.tsx
+++ b/src/app/pages/Boards/Boards.tsx
@@ -49,7 +49,17 @@ export default function Boards(): JSX.Element {
     return sortBoardPages(pages).map(page => {
       const pageMembers = members.filter((member) => {
         const pluralRoles = member.roles.map((role) => `${role}s`)
-        return member.roles.includes(page.page_code) || pluralRoles.includes(page.page_code);
+        const hasMatchingRole = member.roles.includes(page.page_code) || pluralRoles.includes(page.page_code);
+
+        // Include managing-editor and handling-editor in scientific-advisory-board
+        const isScientificAdvisoryBoard = page.page_code === 'scientific-advisory-board';
+        const hasSpecialRoleScientific = member.roles.includes('managing-editor') || member.roles.includes('handling-editor');
+
+        // Include advisory-board in editorial-board
+        const isEditorialBoard = page.page_code === 'editorial-board';
+        const hasSpecialRoleEditorial = member.roles.includes('advisory-board');
+
+        return hasMatchingRole || (isScientificAdvisoryBoard && hasSpecialRoleScientific) || (isEditorialBoard && hasSpecialRoleEditorial);
       });
 
       return {

--- a/src/utils/board.ts
+++ b/src/utils/board.ts
@@ -46,7 +46,10 @@ export enum BOARD_ROLE {
   EDITOR = 'editor',
   CHIEF_EDITOR = 'chief-editor',
   SECRETARY = 'secretary',
-  FORMER_MEMBER = 'former-member'
+  FORMER_MEMBER = 'former-member',
+  ADVISORY_BOARD = 'advisory-board',
+  MANAGING_EDITOR = 'managing-editor',
+  HANDLING_EDITOR = 'handling-editor'
 }
 
 export const defaultBoardRole = (t: TFunction<"translation", undefined>) => {
@@ -66,7 +69,11 @@ export const getBoardRoles = (t: TFunction<"translation", undefined>, roles: str
     { key: BOARD_ROLE.EDITOR, label: t('pages.boards.roles.editor') },
     { key: BOARD_ROLE.CHIEF_EDITOR, label: t('pages.boards.roles.chiefEditor') },
     { key: BOARD_ROLE.SECRETARY, label: t('pages.boards.roles.secretary') },
-    { key: BOARD_ROLE.FORMER_MEMBER, label: t('pages.boards.roles.formerMember') }
+    { key: BOARD_ROLE.FORMER_MEMBER, label: t('pages.boards.roles.formerMember') },
+    { key: BOARD_ROLE.ADVISORY_BOARD, label: t('pages.boards.roles.advisoryBoard') },
+    { key: BOARD_ROLE.MANAGING_EDITOR, label: t('pages.boards.roles.managingEditor') },
+    { key: BOARD_ROLE.HANDLING_EDITOR, label: t('pages.boards.roles.handlingEditor') }
+
   ]
 
   return rolesWithLabels.filter(roleWithLabel => roles.includes(roleWithLabel.key)).map(roleWithLabel => roleWithLabel.label).join(', ')


### PR DESCRIPTION
  - `managing-editor` and `handling-editor` roles now appear in `scientific-advisory-board`
  - `advisory-board` role now appears in `editorial-board`