### PR TITLE
feat(#94):Reorganize editorial boards and display all member roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config for Dependabot
 - Status page link in footer
 - feat: add new pages for About, Boards, and Publish
-- feat(#94): update editor labels for Scientific and Editorial boards
+- feat(#94): update editor labels for Scientific and Editorial boards, and display all member roles
 - Transform for author - ethical charter into an independent page
 
 ### Fixed

--- a/src/app/components/Cards/BoardCard/BoardCard.tsx
+++ b/src/app/components/Cards/BoardCard/BoardCard.tsx
@@ -22,7 +22,7 @@ interface IBoardCardProps {
   setFullMemberIndexCallback: () => void;
 }
 
-export default function BoardCard({ language, t, member, fullCard, blurCard, currentPageCode, setFullMemberIndexCallback }: IBoardCardProps): JSX.Element {
+export default function BoardCard({ language, t, member, fullCard, blurCard, setFullMemberIndexCallback }: IBoardCardProps): JSX.Element {
   if (fullCard) {
     return (
       <div className='boardCard boardCard-full' onClick={setFullMemberIndexCallback}>
@@ -45,9 +45,7 @@ export default function BoardCard({ language, t, member, fullCard, blurCard, cur
                 )}
               </div>
               {member.roles.length > 0 ? (
-                <div className='boardCard-full-initial-person-title-role'>{getBoardRoles(t, member.roles.filter(role =>
-                    role !== currentPageCode && `${role}s` !== currentPageCode
-                ))}</div>
+                <div className='boardCard-full-initial-person-title-role'>{getBoardRoles(t, member.roles)}</div>
               ) : (
                 <div className='boardCard-full-initial-person-title-role'>{defaultBoardRole(t).label}</div>
               )}
@@ -117,9 +115,7 @@ export default function BoardCard({ language, t, member, fullCard, blurCard, cur
             )}
           </div>
           {member.roles.length > 0 ? (
-            <div className='boardCard-person-title-role'>{getBoardRoles(t, member.roles.filter(role =>
-                role !== currentPageCode && `${role}s` !== currentPageCode
-            ))}</div>
+            <div className='boardCard-person-title-role'>{getBoardRoles(t, member.roles)}</div>
           ) : (
             <div className='boardCard-person-title-role'>{defaultBoardRole(t).label}</div>
           )}

--- a/src/app/components/HomeSections/JournalSection/JournalSection.scss
+++ b/src/app/components/HomeSections/JournalSection/JournalSection.scss
@@ -19,7 +19,7 @@
 
     li {
       color: var(--primary-accessible);
-      font-size: 14px;
+      font-size: 16px;
       margin-bottom: 10px;
 
       a {

--- a/src/app/pages/Boards/Boards.tsx
+++ b/src/app/pages/Boards/Boards.tsx
@@ -51,15 +51,15 @@ export default function Boards(): JSX.Element {
         const pluralRoles = member.roles.map((role) => `${role}s`)
         const hasMatchingRole = member.roles.includes(page.page_code) || pluralRoles.includes(page.page_code);
 
-        // Include managing-editor and handling-editor in scientific-advisory-board
+        // Include advisory-board in scientific-advisory-board
         const isScientificAdvisoryBoard = page.page_code === 'scientific-advisory-board';
-        const hasSpecialRoleScientific = member.roles.includes('managing-editor') || member.roles.includes('handling-editor');
+        const hasAdvisoryBoardRole = member.roles.includes('advisory-board');
 
-        // Include advisory-board in editorial-board
+        // Include managing-editor and handling-editor in editorial-board
         const isEditorialBoard = page.page_code === 'editorial-board';
-        const hasSpecialRoleEditorial = member.roles.includes('advisory-board');
+        const hasManagingOrHandlingRole = member.roles.includes('managing-editor') || member.roles.includes('handling-editor');
 
-        return hasMatchingRole || (isScientificAdvisoryBoard && hasSpecialRoleScientific) || (isEditorialBoard && hasSpecialRoleEditorial);
+        return hasMatchingRole || (isScientificAdvisoryBoard && hasAdvisoryBoardRole) || (isEditorialBoard && hasManagingOrHandlingRole);
       });
 
       return {

--- a/src/utils/board.ts
+++ b/src/utils/board.ts
@@ -13,8 +13,8 @@ export enum BOARD_TYPE {
 //Define the sort order for board types - order in array determines display order"
 export const boardTypes = [
   BOARD_TYPE.INTRODUCTION_BOARD,
-  BOARD_TYPE.EDITORIAL_BOARD,
   BOARD_TYPE.SCIENTIFIC_ADVISORY_BOARD,
+  BOARD_TYPE.EDITORIAL_BOARD,
   BOARD_TYPE.TECHNICAL_BOARD,
   BOARD_TYPE.REVIEWERS_BOARD,
   BOARD_TYPE.FORMER_MEMBERS,
@@ -81,7 +81,7 @@ export const getBoardRoles = (t: TFunction<"translation", undefined>, roles: str
 
 /**
  * Sort board members by role priority, then by lastname, then by firstname
- * Priority order: chief-editor (1), editor (2), others (3)
+ * Priority order: chief-editor (1), managing-editor (2), editor (3), others (4)
  * @param members - Array of board members to sort
  * @returns Sorted array of board members
  */
@@ -90,8 +90,9 @@ export const sortBoardMembers = (members: IBoardMember[]): IBoardMember[] => {
     // Helper function to get role priority
     const getRolePriority = (roles: string[]): number => {
       if (roles.includes(BOARD_ROLE.CHIEF_EDITOR)) return 1;
-      if (roles.includes(BOARD_ROLE.EDITOR)) return 2;
-      return 3;
+      if (roles.includes(BOARD_ROLE.MANAGING_EDITOR)) return 2;
+      if (roles.includes(BOARD_ROLE.EDITOR)) return 3;
+      return 4;
     };
 
     // Compare by role priority first


### PR DESCRIPTION
  - Move Scientific advisory board before Editorial board
  - Assign managing-editor and handling-editor to Editorial board
  - Assign advisory-board to Scientific advisory board
  - Add managing-editor to member sorting priority
  - Display all member roles without filtering