### PR TITLE
feat(#106): display copyeditor and webmaster roles in Technical Board…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Empty state message for volumes without articles (EN: "This volume does not yet contain any documents." / FR: "Ce volume ne contient pas encore de documents.")
 - Journal code validation to prevent cross-journal article access - articles now redirect to 404 if they don't belong to the current journal
 - Add volume and section access validation by journal (rvid) to prevent cross-journal access with customized notFound(404) messages
+- Display copyeditor and webmaster members in Technical Board section with role labels
 
 ### Fixed
 

--- a/public/locales/en/en.json
+++ b/public/locales/en/en.json
@@ -381,7 +381,9 @@
         "formerMember": "Former member",
         "advisoryBoard": "Advisory board",
         "managingEditor": "Managing editor",
-        "handlingEditor": "Handling editor"
+        "handlingEditor": "Handling editor",
+        "copyEditor": "Copy editor",
+        "webmaster": "Webmaster"
       }
     },
     "publish": {

--- a/public/locales/fr/fr.json
+++ b/public/locales/fr/fr.json
@@ -381,7 +381,9 @@
         "formerMember": "Ancien/Ancienne membre",
         "advisoryBoard": "Comité consultatif",
         "managingEditor": "Comité de direction",
-        "handlingEditor": "Rédacteur responsable"
+        "handlingEditor": "Rédacteur responsable",
+        "copyEditor": "Préparateur de copie",
+        "webmaster": "Webmaster"
       }
     },
     "publish": {

--- a/src/app/pages/Boards/Boards.tsx
+++ b/src/app/pages/Boards/Boards.tsx
@@ -93,10 +93,17 @@ export default function Boards(): JSX.Element {
         member.roles.includes('managing-editor') ||
         member.roles.includes('handling-editor');
 
+      // Include copyeditor and webmaster in technical-board
+      const isTechnicalBoard = boardType === BOARD_TYPE.TECHNICAL_BOARD;
+      const hasCopyEditorOrWebmasterRole =
+        member.roles.includes('copyeditor') ||
+        member.roles.includes('webmaster');
+
       return (
         hasMatchingRole ||
         (isScientificAdvisoryBoard && hasAdvisoryBoardRole) ||
-        (isEditorialBoard && hasManagingOrHandlingRole)
+        (isEditorialBoard && hasManagingOrHandlingRole) ||
+        (isTechnicalBoard && hasCopyEditorOrWebmasterRole)
       );
     });
   };

--- a/src/utils/board.ts
+++ b/src/utils/board.ts
@@ -50,6 +50,8 @@ export enum BOARD_ROLE {
   ADVISORY_BOARD = 'advisory-board',
   MANAGING_EDITOR = 'managing-editor',
   HANDLING_EDITOR = 'handling-editor',
+  COPY_EDITOR = 'copyeditor',
+  WEBMASTER = 'webmaster',
 }
 
 export const defaultBoardRole = (t: TFunction<'translation', undefined>) => {
@@ -105,6 +107,14 @@ export const getBoardRoles = (
     {
       key: BOARD_ROLE.HANDLING_EDITOR,
       label: t('pages.boards.roles.handlingEditor'),
+    },
+    {
+      key: BOARD_ROLE.COPY_EDITOR,
+      label: t('pages.boards.roles.copyEditor'),
+    },
+    {
+      key: BOARD_ROLE.WEBMASTER,
+      label: t('pages.boards.roles.webmaster'),
     },
   ];
 


### PR DESCRIPTION
 - Add copyeditor and webmaster members to Technical Board section                                                                                                                                                                                                                         
  - Display role labels on member cards    