### PR TITLE
feat(#221):improve journal title display on small screens

### DIFF
--- a/src/app/components/Header/Header.scss
+++ b/src/app/components/Header/Header.scss
@@ -124,12 +124,20 @@
 
   &-journal {
     width: 100%;
-    height: 180px;
+    min-height: 180px;
     display: flex;
+
+    @media (max-width: breakpoints.$sm) {
+      min-height: 170px;
+    }
+
+    @media (max-width: breakpoints.$xs) {
+      min-height: 150px;
+    }
 
     @media (max-width: breakpoints.$xsm),
       (max-width: breakpoints.$sm) and (orientation: landscape) {
-      height: 86px;
+      min-height: 130px;
     }
 
     &-logo {
@@ -165,19 +173,16 @@
       display: flex;
       flex-direction: column;
       align-items: end;
-      padding-right: 80px;
-      padding-bottom: 40px;
+      padding: 30px 80px 20px 20px;
       justify-content: flex-end;
-      overflow: hidden;
+      overflow: visible;
 
       @media (max-width: breakpoints.$sm) {
-        padding-right: 40px;
-        padding-bottom: 20px;
+        padding: 20px 40px 16px 16px;
       }
 
       @media (max-width: breakpoints.$xs) {
-        padding-right: 20px;
-        padding-bottom: 15px;
+        padding: 16px 20px 12px 16px;
       }
     }
 
@@ -185,6 +190,9 @@
       font-size: 42px;
       font-weight: bold;
       text-align: end;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      hyphens: auto;
 
       @media (max-width: breakpoints.$sm) {
         font-size: 28px;
@@ -195,8 +203,8 @@
       }
 
       @media (max-width: breakpoints.$xsm) {
-        padding: 0px 16px 0px 16px;
         font-size: 14px;
+        line-height: 1.2;
       }
     }
 
@@ -205,6 +213,9 @@
       font-weight: bold;
       padding-top: 10px;
       text-align: end;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      hyphens: auto;
 
       @media (max-width: breakpoints.$sm) {
         font-size: 18px;
@@ -216,8 +227,9 @@
       }
 
       @media (max-width: breakpoints.$xsm) {
-        padding: 0px 16px 0px 16px;
+        padding-top: 5px;
         font-size: 12px;
+        line-height: 1.2;
       }
     }
   }


### PR DESCRIPTION
- Add padding-left and padding-top for balanced spacing
- Change overflow from hidden to visible to prevent text cutoff
- Use min-height instead of fixed height for flexible content
- Add word-wrap properties for long titles
- Increase min-height on small screens to accommodate title + subtitle