### PR TITLE
Fix license URL matching and collapsible section subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix license comparison in article sidebar by normalizing trailing slashes in URLs
+- Handle array-shaped `license_ref` in article metadata (pick the `vor` entry or first element)
+- Fix collapsible sections on presentation pages hiding subtitles when collapsed — only hide direct children except the subtitle
 - Fix preheader bar height inconsistency on resize and vertically center its content
 - Fix page content hidden behind fixed header on mobile by correcting main margin-top values
 - Fix empty section rendered on the for-authors page when the page title is empty

--- a/src/app/components/Sidebars/ArticleDetailsSidebar/ArticleDetailsSidebar.tsx
+++ b/src/app/components/Sidebars/ArticleDetailsSidebar/ArticleDetailsSidebar.tsx
@@ -139,10 +139,12 @@ export default function ArticleDetailsSidebar({
   };
 
   const renderLicenseContent = (): JSX.Element | null => {
-    if (!article) return null;
+    if (!article?.license) return null;
 
+    const normalizeUrl = (url: string): string => url.replace(/\/+$/, '');
+    const normalizedLicense = normalizeUrl(article.license);
     const translatedLicense = getLicenseTranslations(t).find(
-      lt => lt.value === article.license
+      lt => normalizeUrl(lt.value) === normalizedLicense
     );
 
     if (!translatedLicense) return null;

--- a/src/app/pages/About/About.scss
+++ b/src/app/pages/About/About.scss
@@ -25,7 +25,7 @@
         display: block;
 
         &-hidden {
-          * {
+          > *:not(.about-content-body-section-subtitle) {
             display: none;
           }
         }

--- a/src/app/pages/Acknowledgements/Acknowledgements.scss
+++ b/src/app/pages/Acknowledgements/Acknowledgements.scss
@@ -26,7 +26,7 @@
         display: block;
 
         &-hidden {
-          * {
+          > *:not(.acknowledgements-content-body-section-subtitle) {
             display: none;
           }
         }

--- a/src/app/pages/Credits/Credits.scss
+++ b/src/app/pages/Credits/Credits.scss
@@ -25,7 +25,7 @@
         display: block;
 
         &-hidden {
-          * {
+          > *:not(.credits-content-body-section-subtitle) {
             display: none;
           }
         }

--- a/src/app/pages/EthicalCharter/EthicalCharter.scss
+++ b/src/app/pages/EthicalCharter/EthicalCharter.scss
@@ -26,7 +26,7 @@
         display: block;
 
         &-hidden {
-          * {
+          > *:not(.ethicalCharter-content-body-section-subtitle) {
             display: none;
           }
         }

--- a/src/app/pages/ForAuthors/ForAuthors.scss
+++ b/src/app/pages/ForAuthors/ForAuthors.scss
@@ -66,7 +66,7 @@
         display: block;
 
         &-hidden {
-          * {
+          > *:not(.forAuthors-content-body-section-subtitle) {
             display: none;
           }
         }

--- a/src/app/pages/ForConferenceOrganisers/ForConferenceOrganisers.scss
+++ b/src/app/pages/ForConferenceOrganisers/ForConferenceOrganisers.scss
@@ -26,7 +26,7 @@
         display: block;
 
         &-hidden {
-          * {
+          > *:not(.forConferenceOrganisers-content-body-section-subtitle) {
             display: none;
           }
         }

--- a/src/app/pages/ForReviewers/ForReviewers.scss
+++ b/src/app/pages/ForReviewers/ForReviewers.scss
@@ -26,7 +26,7 @@
         display: block;
 
         &-hidden {
-          * {
+          > *:not(.forReviewers-content-body-section-subtitle) {
             display: none;
           }
         }

--- a/src/utils/article.ts
+++ b/src/utils/article.ts
@@ -447,13 +447,22 @@ export const formatArticle = (article: RawArticle): FetchedArticle => {
 
     /** Format license */
     let license = undefined;
+    const extractLicenseValue = (licenseRef: unknown): string | undefined => {
+      if (Array.isArray(licenseRef)) {
+        const vor = licenseRef.find(
+          (lr: { '@applies_to'?: string }) => lr['@applies_to'] === 'vor'
+        );
+        return (vor ?? licenseRef[0])?.value;
+      }
+      return (licenseRef as { value?: string })?.value;
+    };
     if (Array.isArray(articleContent.program)) {
-      const licenseRef = articleContent.program.find(
-        p => p.license_ref && p.license_ref.value
-      )?.license_ref;
-      license = licenseRef?.value;
+      const programEntry = articleContent.program.find(
+        (p: { license_ref?: unknown }) => p.license_ref
+      );
+      license = extractLicenseValue(programEntry?.license_ref);
     } else {
-      license = articleContent.program?.license_ref?.value;
+      license = extractLicenseValue(articleContent.program?.license_ref);
     }
 
     /** Format metrics */


### PR DESCRIPTION
## Summary

- **License URL matching**: Normalize trailing slashes when comparing license URLs so that licenses like `https://creativecommons.org/licenses/by/4.0` and `https://creativecommons.org/licenses/by/4.0/` match correctly. Also handle `license_ref` being an array (picking the `vor` entry or falling back to the first element).
- **Collapsible sections**: Fix presentation pages (About, Credits, Acknowledgements, EthicalCharter, ForAuthors, ForReviewers, ForConferenceOrganisers) where collapsing a section hid everything including the subtitle. Now only direct children are hidden, keeping the subtitle visible so users can still identify and expand sections.

## Test plan

- [ ] Verify article license is displayed correctly in the sidebar for articles with trailing-slash and non-trailing-slash license URLs
- [ ] Verify articles with array-shaped `license_ref` metadata display the correct license
- [ ] Verify collapsible sections on presentation pages show subtitles when collapsed
- [ ] Verify expanding a collapsed section still reveals all content