### PR TITLE
fix(#283):Links with formatted text (bold/italic) display [object Obj…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breadcrumbs: use correct paths from config and fix navigation
 - Volume page, display other volumes with a link
 - Fixed truncated Markdown not rendered in /HomeSections/PresentationSection
+- [#283]https://github.com/CCSDForge/episciences-front/issues/283 Links with formatted text (bold/italic) display [object Object] on About page
 
 ### Changed
 

--- a/src/app/pages/About/About.tsx
+++ b/src/app/pages/About/About.tsx
@@ -200,7 +200,7 @@ export default function About(): JSX.Element {
                         target="_blank"
                         className="about-content-body-section-link"
                       >
-                        {props.children?.toString()}
+                        {props.children}
                       </Link>
                     ),
                     h2: ({ ...props }) => {


### PR DESCRIPTION
…ect] on About page